### PR TITLE
Fixed issue with pytest-xdist compatibility

### DIFF
--- a/pytest_tap/plugin.py
+++ b/pytest_tap/plugin.py
@@ -20,7 +20,7 @@ tracker = Tracker()
 
 def pytest_addoption(parser):
     """Include all the command line options."""
-    group = parser.getgroup('terminal reporting', after='general')
+    group = parser.getgroup('terminal reporting', 'reporting', after='general')
     group.addoption(
         '--tap-stream', default=False, action='store_true', help=_(
             'Stream TAP output instead of the default test runner output.'))
@@ -42,7 +42,8 @@ def pytest_configure(config):
     tracker.combined = config.option.tap_combined
     if config.option.tap_stream:
         reporter = config.pluginmanager.getplugin('terminalreporter')
-        config.pluginmanager.unregister(reporter)
+        if reporter:
+            config.pluginmanager.unregister(reporter)
         tracker.streaming = True
         tracker.stream = sys.stdout
         # A common pytest pattern is to use test functions without classes.


### PR DESCRIPTION
This fixes an issue when pytest-xdist is used to run the tests in parallel. To reproduce, run any test file with pytest-tap and pytest-xdist installed and the "--tap-stream" and "--n 2" flags.