### PR TITLE
Add ability to write YAML block based on test marker

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,15 +1,21 @@
 [[source]]
+
 url = "https://pypi.python.org/simple"
 verify_ssl = true
 
+
 [dev-packages]
+
 babel = "*"
-flake8 = "*"
+"flake8" = "*"
 mock = "*"
 requests = "*"
 tox = "*"
 twine = "*"
 
+
 [packages]
+
 pytest = "*"
 "tap.py" = "*"
+pyyaml = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,7 @@ verify_ssl = true
 [dev-packages]
 
 babel = "*"
-"flake8" = "*"
+flake8 = "*"
 mock = "*"
 requests = "*"
 tox = "*"

--- a/pytest_tap/plugin.py
+++ b/pytest_tap/plugin.py
@@ -116,27 +116,10 @@ def _get_yaml_as_text(pytest_mark):
     testids_mark_arg_no = len(pytest_mark.args)
     if testids_mark_arg_no > 1:
         raise TypeError(
-            'Incorrect number of arguments passed to @pytest.mark.TESTIDS expected 1 and received {}'.format(
+            'Incorrect number of arguments passed to @pytest.mark.TESTIDS, expected 1 and received {}'.format(
                 testids_mark_arg_no))
     else:
         yaml_object = yaml.load(pytest_mark.args[0])
         yaml_text_block = '\n---\n' + yaml.dump(yaml_object, default_flow_style=False) + '...'
         indented_yaml_text_block = '\n   '.join(yaml_text_block.split('\n'))
         return indented_yaml_text_block
-
-
-# def tap_yaml(tap_yaml_text):
-#     """Parse a YAML string decorator to a text block and add to test outcome"""
-#     def tap_yaml_decorator(test_method):
-#         def wrapper(self, arg2):
-#             test_method(self, arg2)
-#             tap_yaml_block = _create_yaml_text_block(tap_yaml_text)
-#             self._outcome.result.tap_yaml_block = tap_yaml_block
-#         return wrapper
-#     return tap_yaml_decorator
-
-# def _create_yaml_text_block(tap_yaml_text):
-#     yaml_object = yaml.load(tap_yaml_text)
-#     yaml_text_block = '\n---\n' + yaml.dump(yaml_object, default_flow_style=False) + '...'
-#     indented_yaml_text_block = '\n   '.join(yaml_text_block.split('\n'))
-#     return indented_yaml_text_block

--- a/pytest_tap/plugin.py
+++ b/pytest_tap/plugin.py
@@ -106,6 +106,7 @@ def pytest_unconfigure(config):
 
 
 def _get_yaml_as_string_from_mark(marker):
+    """Gets yaml and converts to text"""
     testids_mark_arg_no = len(marker.args)
     if testids_mark_arg_no > 1:
         raise TypeError(
@@ -122,6 +123,7 @@ def _get_yaml_as_string_from_mark(marker):
 
 
 def _get_yaml_from_user_properties(user_properties):
+    """Gets yaml text from test report user properties"""
     test_yaml = ''
     for i, e in enumerate(user_properties):
         if e[0] == 'test_yaml':

--- a/pytest_tap/tests/test_plugin.py
+++ b/pytest_tap/tests/test_plugin.py
@@ -70,16 +70,19 @@ class TestPlugin(unittest.TestCase):
         plugin.tracker = mock.Mock()
         location = ('test_file.py', 1, 'TestFake.test_me')
         user_properties = [('test_yaml', 'An example YAML string')]
-        report = mock.Mock(when='call', outcome='passed', location=location, user_properties=user_properties)
+        report = mock.Mock(when='call', outcome='passed', location=location,
+                           user_properties=user_properties)
         plugin.pytest_runtest_logreport(report)
         plugin.tracker.add_ok.assert_called_once_with(
-            'test_file.py', 'test_file.py::TestFake.test_me', directive='An example YAML string')
+            'test_file.py', 'test_file.py::TestFake.test_me',
+            directive='An example YAML string')
 
     def test_tracks_not_ok(self):
         plugin.tracker = mock.Mock()
         location = ('test_file.py', 1, 'TestFake.test_me')
         user_properties = [('test_yaml', 'An example YAML string')]
-        report = mock.Mock(when='call', outcome='failed', location=location, user_properties=user_properties)
+        report = mock.Mock(when='call', outcome='failed', location=location,
+                           user_properties=user_properties)
         plugin.pytest_runtest_logreport(report)
         plugin.tracker.add_not_ok.assert_called_once_with(
             'test_file.py', 'test_file.py::TestFake.test_me',
@@ -102,8 +105,8 @@ class TestPlugin(unittest.TestCase):
         location = ('test_file.py', 1, 'TestFake.test_me')
         user_properties = [('test_yaml', 'An example YAML string')]
         report = mock.Mock(
-            when='call', outcome='skipped', location=location, wasxfail=''
-            , user_properties=user_properties)
+            when='call', outcome='skipped', location=location, wasxfail='',
+            user_properties=user_properties)
         plugin.pytest_runtest_logreport(report)
         plugin.tracker.add_skip.assert_called_once_with(
             'test_file.py', 'test_file.py::TestFake.test_me', '')
@@ -139,7 +142,9 @@ class TestPlugin(unittest.TestCase):
         plugin.tracker = mock.Mock()
         location = ('tests/test_file.py', 1, 'TestFake.test_me')
         user_properties = [('test_yaml', 'An example YAML string')]
-        report = mock.Mock(when='call', outcome='passed', location=location, user_properties=user_properties)
+        report = mock.Mock(when='call', outcome='passed', location=location,
+                           user_properties=user_properties)
         plugin.pytest_runtest_logreport(report)
         plugin.tracker.add_ok.assert_called_once_with(
-            'tests/test_file.py', 'tests/test_file.py::TestFake.test_me', directive='An example YAML string')
+            'tests/test_file.py', 'tests/test_file.py::TestFake.test_me',
+            directive='An example YAML string')

--- a/pytest_tap/tests/test_plugin.py
+++ b/pytest_tap/tests/test_plugin.py
@@ -69,27 +69,30 @@ class TestPlugin(unittest.TestCase):
     def test_tracks_ok(self):
         plugin.tracker = mock.Mock()
         location = ('test_file.py', 1, 'TestFake.test_me')
-        report = mock.Mock(when='call', outcome='passed', location=location, tap_yaml_block='Example YAML')
+        user_properties = [('test_yaml', 'An example YAML string')]
+        report = mock.Mock(when='call', outcome='passed', location=location, user_properties=user_properties)
         plugin.pytest_runtest_logreport(report)
         plugin.tracker.add_ok.assert_called_once_with(
-            'test_file.py', 'test_file.py::TestFake.test_me', directive='Example YAML')
+            'test_file.py', 'test_file.py::TestFake.test_me', directive='An example YAML string')
 
     def test_tracks_not_ok(self):
         plugin.tracker = mock.Mock()
         location = ('test_file.py', 1, 'TestFake.test_me')
-        report = mock.Mock(when='call', outcome='failed', location=location, tap_yaml_block='Example YAML')
+        user_properties = [('test_yaml', 'An example YAML string')]
+        report = mock.Mock(when='call', outcome='failed', location=location, user_properties=user_properties)
         plugin.pytest_runtest_logreport(report)
         plugin.tracker.add_not_ok.assert_called_once_with(
             'test_file.py', 'test_file.py::TestFake.test_me',
-            diagnostics='', directive='Example YAML')
+            diagnostics='', directive='An example YAML string')
 
     def test_tracks_skip(self):
         plugin.tracker = mock.Mock()
         location = ('test_file.py', 1, 'TestFake.test_me')
         longrepr = ('', '', 'Skipped: a reason')
+        user_properties = [('test_yaml', 'An example YAML string')]
         report = mock.Mock(
             when='setup', outcome='skipped', location=location,
-            longrepr=longrepr)
+            longrepr=longrepr, user_properties=user_properties)
         plugin.pytest_runtest_logreport(report)
         plugin.tracker.add_skip.assert_called_once_with(
             'test_file.py', 'test_file.py::TestFake.test_me', 'a reason')
@@ -97,8 +100,10 @@ class TestPlugin(unittest.TestCase):
     def test_tracks_xfail(self):
         plugin.tracker = mock.Mock()
         location = ('test_file.py', 1, 'TestFake.test_me')
+        user_properties = [('test_yaml', 'An example YAML string')]
         report = mock.Mock(
-            when='call', outcome='skipped', location=location, wasxfail='')
+            when='call', outcome='skipped', location=location, wasxfail=''
+            , user_properties=user_properties)
         plugin.pytest_runtest_logreport(report)
         plugin.tracker.add_skip.assert_called_once_with(
             'test_file.py', 'test_file.py::TestFake.test_me', '')
@@ -133,7 +138,8 @@ class TestPlugin(unittest.TestCase):
     def test_path_pytest(self):
         plugin.tracker = mock.Mock()
         location = ('tests/test_file.py', 1, 'TestFake.test_me')
-        report = mock.Mock(when='call', outcome='passed', location=location, tap_yaml_block='Example YAML')
+        user_properties = [('test_yaml', 'An example YAML string')]
+        report = mock.Mock(when='call', outcome='passed', location=location, user_properties=user_properties)
         plugin.pytest_runtest_logreport(report)
         plugin.tracker.add_ok.assert_called_once_with(
-            'tests/test_file.py', 'tests/test_file.py::TestFake.test_me', directive='Example YAML')
+            'tests/test_file.py', 'tests/test_file.py::TestFake.test_me', directive='An example YAML string')

--- a/pytest_tap/tests/test_plugin.py
+++ b/pytest_tap/tests/test_plugin.py
@@ -69,19 +69,19 @@ class TestPlugin(unittest.TestCase):
     def test_tracks_ok(self):
         plugin.tracker = mock.Mock()
         location = ('test_file.py', 1, 'TestFake.test_me')
-        report = mock.Mock(when='call', outcome='passed', location=location)
+        report = mock.Mock(when='call', outcome='passed', location=location, tap_yaml_block='Example YAML')
         plugin.pytest_runtest_logreport(report)
         plugin.tracker.add_ok.assert_called_once_with(
-            'test_file.py', 'test_file.py::TestFake.test_me')
+            'test_file.py', 'test_file.py::TestFake.test_me', directive='Example YAML')
 
     def test_tracks_not_ok(self):
         plugin.tracker = mock.Mock()
         location = ('test_file.py', 1, 'TestFake.test_me')
-        report = mock.Mock(when='call', outcome='failed', location=location)
+        report = mock.Mock(when='call', outcome='failed', location=location, tap_yaml_block='Example YAML')
         plugin.pytest_runtest_logreport(report)
         plugin.tracker.add_not_ok.assert_called_once_with(
             'test_file.py', 'test_file.py::TestFake.test_me',
-            diagnostics='')
+            diagnostics='', directive='Example YAML')
 
     def test_tracks_skip(self):
         plugin.tracker = mock.Mock()
@@ -133,7 +133,7 @@ class TestPlugin(unittest.TestCase):
     def test_path_pytest(self):
         plugin.tracker = mock.Mock()
         location = ('tests/test_file.py', 1, 'TestFake.test_me')
-        report = mock.Mock(when='call', outcome='passed', location=location)
+        report = mock.Mock(when='call', outcome='passed', location=location, tap_yaml_block='Example YAML')
         plugin.pytest_runtest_logreport(report)
         plugin.tracker.add_ok.assert_called_once_with(
-            'tests/test_file.py', 'tests/test_file.py::TestFake.test_me')
+            'tests/test_file.py', 'tests/test_file.py::TestFake.test_me', directive='Example YAML')

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ if __name__ == '__main__':
         install_requires=[
             'pytest',
             'tap.py',
+            'pyyaml'
         ],
         classifiers=[
             'Development Status :: 5 - Production/Stable',

--- a/tox.ini
+++ b/tox.ini
@@ -39,6 +39,7 @@ deps =
     coverage
     mock
     pytest
+    pyyaml
 commands =
     coverage run --source pytest_tap -m py.test pytest_tap
     codecov

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,7 @@ envlist =
 deps =
     mock
     pytest
+    pyyaml
 commands = py.test --tap-combined {envsitepackagesdir}/pytest_tap
 
 [testenv:flake8]


### PR DESCRIPTION
@mblayman - this is the code I've used to get custom YAML blocks from a test into the TAP reports. I've done it using @pytest.mark functionality and using that to add to the `user_proerties` attribute of a test case as part of the `pytest_collection_modifyitems` hook. The idea is that you can mark a test with actual YAML syntax and the plugin then loads that and converts it to the string syntax needed by tappy to write the tap file e.g.

`@pytest.mark.test_yaml("""
    tests:
        test1: SD-1278
        test2: SD1728
    """)
    def test_function(self, data):`

I've tried a few iterations so far and this feels like the nicest but happy to discuss those other options. 

I haven't fully fleshed this out yet (adding tests and supporting previous versions of pytest - this requires 3.6 currently) as I wanted to get some feedback before I went the whole hog.

A few thoughts:
- I'm not sure pytest mark was meant to take large chunks of text like a YAML
- It would be nice if a file could be passed into the decorator and I'm not sure mark can/should do this