### PR TITLE
Fix AttributeError: 'TerminalWriter' object has no attribute '_write_source'

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -5,6 +5,7 @@ Contributors
 
 * Dan Dofter
 * Erik Cederstrand
+* Frédéric Mangano-Tarumi
 * Greg Sadetsky
 * Matt Layman
 * Måns Ansgariusson - ARM Sweden

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ if __name__ == "__main__":
         include_package_data=True,
         zip_safe=False,
         platforms="any",
-        install_requires=["pytest", "tap.py>=3.0,<4.0"],
+        install_requires=["pytest>=3.0", "tap.py>=3.0,<4.0"],
         classifiers=[
             "Development Status :: 5 - Production/Stable",
             "Framework :: Pytest",

--- a/src/pytest_tap/plugin.py
+++ b/src/pytest_tap/plugin.py
@@ -1,10 +1,8 @@
 # Copyright (c) 2020, Matt Layman
 
 import sys
-from io import StringIO
 
 import pytest
-from py.io import TerminalWriter
 from tap.formatter import format_as_diagnostics
 from tap.tracker import Tracker
 
@@ -129,10 +127,7 @@ def pytest_runtest_logreport(report):
 
 def _make_as_diagnostics(report):
     """Format a report as TAP diagnostic output."""
-    out = StringIO()
-    tw = TerminalWriter(file=out)
-    report.toterminal(tw)
-    lines = out.getvalue().splitlines(True)
+    lines = report.longreprtext.splitlines(True)
     return format_as_diagnostics(lines)
 
 


### PR DESCRIPTION
TL;DR: py.io.TerminalWriter is not supported anymore since pytest now expects
its custom subclass instead (_pytest._io.TerminalWriter), but
pytest.reports.BaseReport.longreprtext provides us with a good
alternative whose implementation is very similar to what we had.

Error reporting with pytest-tap is currently broken. See below the traceback I
get when I run pytest-tap’s test suite. Most tests fail because of that error.

The missing _write_source method is expected from _pytest._io.TerminalWriter,
which subclasses py.io.TerminalWriter. It looks like that was introduced with 5.4.
https://github.com/pytest-dev/pytest/blob/5.4.1/src/_pytest/_io/__init__.py#L7-L8

The BaseReport class from pytest already supplies a longreprtext method which
does almost what pytest-tap used to do, up to strip().
https://github.com/pytest-dev/pytest/blob/5.4.1/src/_pytest/reports.py#L77-L89

I don’t think the extra strip() would break anything since it’s meant to be text
for the user. Besides, it’s the official text representation of the report
defined by pytest. If strip is undesirable in some circumstances, pytest should
remove it at the source.

We could alternatively instantiate pytest’s custom TerminalWriter, but
longreprtext, introduced in pytest 3.0, sounds like a more stable solution than
using a private API.

```
INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "/home/fmang/dev/pytest-tap/venv/lib/python3.8/site-packages/_pytest/main.py", line 191, in wrap_session
INTERNALERROR>     session.exitstatus = doit(config, session) or 0
INTERNALERROR>   File "/home/fmang/dev/pytest-tap/venv/lib/python3.8/site-packages/_pytest/main.py", line 247, in _main
INTERNALERROR>     config.hook.pytest_runtestloop(session=session)
INTERNALERROR>   File "/home/fmang/dev/pytest-tap/venv/lib/python3.8/site-packages/pluggy/hooks.py", line 286, in __call__
INTERNALERROR>     return self._hookexec(self, self.get_hookimpls(), kwargs)
INTERNALERROR>   File "/home/fmang/dev/pytest-tap/venv/lib/python3.8/site-packages/pluggy/manager.py", line 93, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook, methods, kwargs)
INTERNALERROR>   File "/home/fmang/dev/pytest-tap/venv/lib/python3.8/site-packages/pluggy/manager.py", line 84, in <lambda>
INTERNALERROR>     self._inner_hookexec = lambda hook, methods, kwargs: hook.multicall(
INTERNALERROR>   File "/home/fmang/dev/pytest-tap/venv/lib/python3.8/site-packages/pluggy/callers.py", line 208, in _multicall
INTERNALERROR>     return outcome.get_result()
INTERNALERROR>   File "/home/fmang/dev/pytest-tap/venv/lib/python3.8/site-packages/pluggy/callers.py", line 80, in get_result
INTERNALERROR>     raise ex[1].with_traceback(ex[2])
INTERNALERROR>   File "/home/fmang/dev/pytest-tap/venv/lib/python3.8/site-packages/pluggy/callers.py", line 187, in _multicall
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>   File "/home/fmang/dev/pytest-tap/venv/lib/python3.8/site-packages/_pytest/main.py", line 272, in pytest_runtestloop
INTERNALERROR>     item.config.hook.pytest_runtest_protocol(item=item, nextitem=nextitem)
INTERNALERROR>   File "/home/fmang/dev/pytest-tap/venv/lib/python3.8/site-packages/pluggy/hooks.py", line 286, in __call__
INTERNALERROR>     return self._hookexec(self, self.get_hookimpls(), kwargs)
INTERNALERROR>   File "/home/fmang/dev/pytest-tap/venv/lib/python3.8/site-packages/pluggy/manager.py", line 93, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook, methods, kwargs)
INTERNALERROR>   File "/home/fmang/dev/pytest-tap/venv/lib/python3.8/site-packages/pluggy/manager.py", line 84, in <lambda>
INTERNALERROR>     self._inner_hookexec = lambda hook, methods, kwargs: hook.multicall(
INTERNALERROR>   File "/home/fmang/dev/pytest-tap/venv/lib/python3.8/site-packages/pluggy/callers.py", line 208, in _multicall
INTERNALERROR>     return outcome.get_result()
INTERNALERROR>   File "/home/fmang/dev/pytest-tap/venv/lib/python3.8/site-packages/pluggy/callers.py", line 80, in get_result
INTERNALERROR>     raise ex[1].with_traceback(ex[2])
INTERNALERROR>   File "/home/fmang/dev/pytest-tap/venv/lib/python3.8/site-packages/pluggy/callers.py", line 187, in _multicall
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>   File "/home/fmang/dev/pytest-tap/venv/lib/python3.8/site-packages/_pytest/runner.py", line 85, in pytest_runtest_protocol
INTERNALERROR>     runtestprotocol(item, nextitem=nextitem)
INTERNALERROR>   File "/home/fmang/dev/pytest-tap/venv/lib/python3.8/site-packages/_pytest/runner.py", line 100, in runtestprotocol
INTERNALERROR>     reports.append(call_and_report(item, "call", log))
INTERNALERROR>   File "/home/fmang/dev/pytest-tap/venv/lib/python3.8/site-packages/_pytest/runner.py", line 190, in call_and_report
INTERNALERROR>     hook.pytest_runtest_logreport(report=report)
INTERNALERROR>   File "/home/fmang/dev/pytest-tap/venv/lib/python3.8/site-packages/pluggy/hooks.py", line 286, in __call__
INTERNALERROR>     return self._hookexec(self, self.get_hookimpls(), kwargs)
INTERNALERROR>   File "/home/fmang/dev/pytest-tap/venv/lib/python3.8/site-packages/pluggy/manager.py", line 93, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook, methods, kwargs)
INTERNALERROR>   File "/home/fmang/dev/pytest-tap/venv/lib/python3.8/site-packages/pluggy/manager.py", line 84, in <lambda>
INTERNALERROR>     self._inner_hookexec = lambda hook, methods, kwargs: hook.multicall(
INTERNALERROR>   File "/home/fmang/dev/pytest-tap/venv/lib/python3.8/site-packages/pluggy/callers.py", line 208, in _multicall
INTERNALERROR>     return outcome.get_result()
INTERNALERROR>   File "/home/fmang/dev/pytest-tap/venv/lib/python3.8/site-packages/pluggy/callers.py", line 80, in get_result
INTERNALERROR>     raise ex[1].with_traceback(ex[2])
INTERNALERROR>   File "/home/fmang/dev/pytest-tap/venv/lib/python3.8/site-packages/pluggy/callers.py", line 187, in _multicall
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>   File "/home/fmang/pytest-tap/src/pytest_tap/plugin.py", line 113, in pytest_runtest_logreport
INTERNALERROR>   File "/home/fmang/pytest-tap/src/pytest_tap/plugin.py", line 134, in _make_as_diagnostics
INTERNALERROR>   File "/home/fmang/dev/pytest-tap/venv/lib/python3.8/site-packages/_pytest/reports.py", line 65, in toterminal
INTERNALERROR>     longrepr.toterminal(out)
INTERNALERROR>   File "/home/fmang/dev/pytest-tap/venv/lib/python3.8/site-packages/_pytest/_code/code.py", line 962, in toterminal
INTERNALERROR>     element[0].toterminal(tw)
INTERNALERROR>   File "/home/fmang/dev/pytest-tap/venv/lib/python3.8/site-packages/_pytest/_code/code.py", line 992, in toterminal
INTERNALERROR>     entry.toterminal(tw)
INTERNALERROR>   File "/home/fmang/dev/pytest-tap/venv/lib/python3.8/site-packages/_pytest/_code/code.py", line 1080, in toterminal
INTERNALERROR>     self._write_entry_lines(tw)
INTERNALERROR>   File "/home/fmang/dev/pytest-tap/venv/lib/python3.8/site-packages/_pytest/_code/code.py", line 1062, in _write_entry_lines
INTERNALERROR>     tw._write_source(source_lines, indents)
INTERNALERROR> AttributeError: 'TerminalWriter' object has no attribute '_write_source'
```

* [ ] Is your name/identity in the AUTHORS file alphabetically?
* [ ] Did you write a test to verify your code change?
* [x] Is CI passing?
