### PR TITLE
Match xfail behavior for pytest and unitttest with TAP spec

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -6,6 +6,9 @@ Version 3.2, To Be Released
 
 * Add support for Python 3.8.
 * Add support for Python 3.9.
+* Handle ``unittest.expectedFailure`` and ``pytest.xfail``
+  in a way that is more consistent
+  with the TAP specification.
 
 Version 3.1, Released March 25, 2020
 ------------------------------------

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -134,12 +134,41 @@ def test_xfail_strict_function(testdir):
 
     result.stdout.fnmatch_lines(
         [
-            (
-                "ok 1 test_xfail_strict_function.py::test_unexpected_pass "
-                "# TODO unexpected success: a reason"
-            ),
+            "ok 1 test_xfail_strict_function.py::test_unexpected_pass "
+            "# TODO unexpected success: a reason",
             "not ok 2 test_xfail_strict_function.py::test_broken # TODO",
             "# [XPASS(strict)] a reason",
+        ]
+    )
+
+
+def test_unittest_expected_failure(testdir):
+    """The plugin handles unittest's expectedFailure decorator behavior."""
+    testdir.makepyfile(
+        """
+        import pytest
+        import unittest
+
+        class TestExpectedFailure(unittest.TestCase):
+            @unittest.expectedFailure
+            def test_when_failing(self):
+                assert False
+
+            @unittest.expectedFailure
+            def test_when_passing(self):
+                assert True
+    """
+    )
+    result = testdir.runpytest_subprocess("--tap-stream")
+
+    result.stdout.fnmatch_lines(
+        [
+            "not ok 1 test_unittest_expected_failure.py::"
+            "TestExpectedFailure.test_when_failing"
+            " # TODO expected failure: reason: ",
+            "ok 2 test_unittest_expected_failure.py::"
+            "TestExpectedFailure.test_when_passing"
+            " # TODO unexpected success: reason: ",
         ]
     )
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -215,11 +215,11 @@ def test_unittest_expected_failure(testdir):
     result.stdout.fnmatch_lines(
         [
             "not ok 1 test_unittest_expected_failure.py::"
-            "TestExpectedFailure.test_when_failing"
-            " # TODO expected failure",
+            "TestExpectedFailure.test_when_failing "
+            "# TODO expected failure",
             "ok 2 test_unittest_expected_failure.py::"
-            "TestExpectedFailure.test_when_passing"
-            " # TODO unexpected success",
+            "TestExpectedFailure.test_when_passing "
+            "# TODO unexpected success",
         ]
     )
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -57,7 +57,7 @@ def test_stream(testdir, sample_test_file):
             "ok 3 test_stream.py::test_params[foo]",
             "ok 4 test_stream.py::test_params[bar]",
             "ok 5 test_stream.py::test_skipped # SKIP some reason",
-            "ok 6 test_stream.py::test_broken # TODO expected failure: a reason",
+            "not ok 6 test_stream.py::test_broken # TODO expected failure: a reason",
         ]
     )
 
@@ -78,7 +78,7 @@ def test_combined(testdir, sample_test_file):
         "ok 3 test_combined.py::test_params[foo]",
         "ok 4 test_combined.py::test_params[bar]",
         "ok 5 test_combined.py::test_skipped # SKIP some reason",
-        "ok 6 test_combined.py::test_broken # TODO expected failure: a reason",
+        "not ok 6 test_combined.py::test_broken # TODO expected failure: a reason",
     ]
     # If the dependencies for version 13 happen to be installed, tweak the output.
     if ENABLE_VERSION_13:
@@ -112,32 +112,83 @@ def test_outdir(testdir, sample_test_file):
     assert testresults.check()
 
 
-def test_xfail_strict_function(testdir):
-    """An xfail with strict on will fail when it unexpectedly passes.
-
-    The xfail should look like an xfail by including the TODO directive.
-    """
+def test_xfail_no_reason(testdir):
+    """xfails output gracefully when no reason is provided."""
     testdir.makepyfile(
         """
         import pytest
 
-        @pytest.mark.xfail(reason='a reason')
-        def test_unexpected_pass():
+        @pytest.mark.xfail(strict=False)
+        def test_unexpected_success():
             assert True
 
-        @pytest.mark.xfail(reason='a reason', strict=True)
-        def test_broken():
-            assert True
+        @pytest.mark.xfail(strict=False)
+        def test_expected_failure():
+            assert False
     """
     )
     result = testdir.runpytest_subprocess("--tap-stream")
 
     result.stdout.fnmatch_lines(
         [
-            "ok 1 test_xfail_strict_function.py::test_unexpected_pass "
+            "ok 1 test_xfail_no_reason.py::test_unexpected_success "
+            "# TODO unexpected success",
+            "not ok 2 test_xfail_no_reason.py::test_expected_failure "
+            "# TODO expected failure",
+        ]
+    )
+
+
+def test_xfail_nonstrict(testdir):
+    """Non-strict xfails are treated as TODO directives."""
+    testdir.makepyfile(
+        """
+        import pytest
+
+        @pytest.mark.xfail(strict=False, reason='a reason')
+        def test_unexpected_success():
+            assert True
+
+        @pytest.mark.xfail(strict=False, reason='a reason')
+        def test_expected_failure():
+            assert False
+    """
+    )
+    result = testdir.runpytest_subprocess("--tap-stream")
+
+    result.stdout.fnmatch_lines(
+        [
+            "ok 1 test_xfail_nonstrict.py::test_unexpected_success "
             "# TODO unexpected success: a reason",
-            "not ok 2 test_xfail_strict_function.py::test_broken # TODO",
-            "# [XPASS(strict)] a reason",
+            "not ok 2 test_xfail_nonstrict.py::test_expected_failure "
+            "# TODO expected failure: a reason",
+        ]
+    )
+
+
+def test_xfail_strict(testdir):
+    """xfail strict mode handles expected behavior."""
+    testdir.makepyfile(
+        """
+        import pytest
+
+        @pytest.mark.xfail(strict=True, reason='a reason')
+        def test_unexpected_success():
+            assert True
+
+        @pytest.mark.xfail(strict=True, reason='a reason')
+        def test_expected_failure():
+            assert False
+    """
+    )
+    result = testdir.runpytest_subprocess("--tap-stream")
+
+    result.stdout.fnmatch_lines(
+        [
+            "not ok 1 test_xfail_strict.py::test_unexpected_success "
+            "# unexpected success: [XPASS(strict)] a reason",
+            "not ok 2 test_xfail_strict.py::test_expected_failure "
+            "# TODO expected failure: a reason",
         ]
     )
 
@@ -165,10 +216,10 @@ def test_unittest_expected_failure(testdir):
         [
             "not ok 1 test_unittest_expected_failure.py::"
             "TestExpectedFailure.test_when_failing"
-            " # TODO expected failure: reason: ",
+            " # TODO expected failure",
             "ok 2 test_unittest_expected_failure.py::"
             "TestExpectedFailure.test_when_passing"
-            " # TODO unexpected success: reason: ",
+            " # TODO unexpected success",
         ]
     )
 


### PR DESCRIPTION
This PR is intended to make the all the different xfail behaviors work (including pytest xfail and unittest.expectedFailure) and be consistent with the TAP specification.

Here's the truth table that I expect.

|Failure type|Test result|TAP output|
|-|-|-|
|`unitest.expectedFailure`|PASS|`ok 1 test_name # TODO unexpected success`|
|`unitest.expectedFailure`|FAIL|`not ok 1 test_name # TODO expected failure`|
|`pytest.mark.xfail(strict=False reason='the reason')`|PASS|`ok 1 test_name # TODO unexpected success: the reason`|
|`pytest.mark.xfail(strict=False reason='the reason')`|FAIL|`not ok 1 test_name # TODO expected failure: the reason`|
|`pytest.mark.xfail(strict=True reason='the reason')`|PASS|`not ok 1 test_name # unexpected success: [XPASS(strict)] the reason`|
|`pytest.mark.xfail(strict=True reason='the reason')`|FAIL|`not ok 1 test_name # TODO expected failure: the reason`|

Based on that truth table, there are a number of things in the plugin that need to change.

1. `unittest.expectedFailure` is backwards currently compared to the table. Fixing this will bring the behavior in line with `TAPTestResult` from tappy.
2. Strict unexpected success reports as `TODO`, but it should be treated as a non-TODO failure.

To accept your contribution, please complete the checklist below.

* [x] Is your name/identity in the AUTHORS file alphabetically?
* [x] Did you write a test to verify your code change?
* [x] Is CI passing?

Fixes #55 (eventually)