### PR TITLE
Add logging to TAP file

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,6 +4,7 @@ Contributors
 ------------
 
 * Allison Karlitskaya
+* Cody D'Ambrosio
 * Dan Dofter
 * Erik Cederstrand
 * Frédéric Mangano-Tarumi

--- a/conftest.py
+++ b/conftest.py
@@ -8,11 +8,16 @@ def sample_test_file(testdir):
     testdir.makepyfile(
         """
         import pytest
+        import logging
+
+        LOGGER = logging.getLogger(__name__)
 
         def test_ok():
+            LOGGER.info("Running test_ok")
             assert True
 
         def test_not_ok():
+            LOGGER.error("Running test_not_ok")
             assert False
 
         @pytest.mark.parametrize('param', ("foo", "bar"))

--- a/conftest.py
+++ b/conftest.py
@@ -14,6 +14,7 @@ def sample_test_file(testdir):
 
         def test_ok():
             LOGGER.info("Running test_ok")
+            LOGGER.debug("Debug logging info")
             assert True
 
         def test_not_ok():

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ if __name__ == "__main__":
         include_package_data=True,
         zip_safe=False,
         platforms="any",
-        install_requires=["pytest>=3.0", "tap.py>=3.0,<4.0"],
+        install_requires=["pytest>=3.0", "tap.py>=3.2,<4.0"],
         classifiers=[
             "Development Status :: 5 - Production/Stable",
             "Framework :: Pytest",

--- a/src/pytest_tap/plugin.py
+++ b/src/pytest_tap/plugin.py
@@ -9,6 +9,7 @@ SHOW_CAPTURE_LOG = ("log", "all")
 SHOW_CAPTURE_OUT = ("stdout", "all")
 SHOW_CAPTUER_ERR = ("stderr", "all")
 
+
 class TAPPlugin:
     def __init__(self, config: pytest.Config) -> None:
         self._tracker = Tracker(

--- a/src/pytest_tap/plugin.py
+++ b/src/pytest_tap/plugin.py
@@ -5,6 +5,9 @@ import pytest
 from tap.formatter import format_as_diagnostics
 from tap.tracker import Tracker
 
+SHOW_CAPTURE_LOG = ("log", "all")
+SHOW_CAPTURE_OUT = ("system-out", "out-err", "all")
+SHOW_CAPTUER_ERR = ("system-err", "out-err", "all")
 
 class TAPPlugin:
     def __init__(self, config: pytest.Config) -> None:
@@ -185,18 +188,21 @@ def _make_as_diagnostics(report, tap_logging):
     """Format a report as TAP diagnostic output."""
     lines = report.longreprtext.splitlines(keepends=True)
 
-    if tap_logging in ["log", "all"]:
-        lines[-1] += "\n"
+    if tap_logging in SHOW_CAPTURE_LOG:
+        if lines:
+            lines[-1] += "\n"
         lines += ["--- Captured Log ---\n"] + (
             report.caplog.splitlines(keepends=True) or [""]
         )
-    if tap_logging in ["system-out", "out-err", "all"]:
-        lines[-1] += "\n"
+    if tap_logging in SHOW_CAPTURE_OUT:
+        if lines:
+            lines[-1] += "\n"
         lines += ["--- Captured Out ---\n"] + (
             report.capstdout.splitlines(keepends=True) or [""]
         )
-    if tap_logging in ["system-err", "out-err", "all"]:
-        lines[-1] += "\n"
+    if tap_logging in SHOW_CAPTUER_ERR:
+        if lines:
+            lines[-1] += "\n"
         lines += ["--- Captured Err ---\n"] + (
             report.capstderr.splitlines(keepends=True) or [""]
         )

--- a/src/pytest_tap/plugin.py
+++ b/src/pytest_tap/plugin.py
@@ -177,12 +177,12 @@ def _make_as_diagnostics(report, tap_logging):
 
     if tap_logging in ["log", "all"]:
         lines[-1] += "\n"
-        lines += [" Captured Log \n"] + (report.caplog.splitlines(keepends=True) or [""])
+        lines += ["--- Captured Log ---\n"] + (report.caplog.splitlines(keepends=True) or [""])
     if tap_logging in ["system-out", "out-err", "all"]:
         lines[-1] += "\n"
-        lines += [" Captured Out \n"] + (report.capstdout.splitlines(keepends=True) or [""])
+        lines += ["--- Captured Out ---\n"] + (report.capstdout.splitlines(keepends=True) or [""])
     if tap_logging in ["system-err", "out-err", "all"]:
         lines[-1] += "\n"
-        lines += [" Captured Err \n"] + (report.capstderr.splitlines(keepends=True) or [""])
+        lines += ["--- Captured Err ---\n"] + (report.capstderr.splitlines(keepends=True) or [""])
 
     return format_as_diagnostics(lines)

--- a/src/pytest_tap/plugin.py
+++ b/src/pytest_tap/plugin.py
@@ -175,16 +175,14 @@ def _make_as_diagnostics(report, tap_logging):
     """Format a report as TAP diagnostic output."""
     lines = report.longreprtext.splitlines(keepends=True)
 
-    content_all = format_as_diagnostics(lines)
-
     if tap_logging in ["log", "all"]:
-        content_all += format_as_diagnostics(" Captured Log ")
-        content_all += format_as_diagnostics(report.caplog.splitlines(keepends=True))
+        lines[-1] += "\n"
+        lines += [" Captured Log \n"] + (report.caplog.splitlines(keepends=True) or [""])
     if tap_logging in ["system-out", "out-err", "all"]:
-        content_all += format_as_diagnostics(" Captured Out ")
-        content_all += format_as_diagnostics(report.capstdout.splitlines(keepends=True))
+        lines[-1] += "\n"
+        lines += [" Captured Out \n"] + (report.capstdout.splitlines(keepends=True) or [""])
     if tap_logging in ["system-err", "out-err", "all"]:
-        content_all += format_as_diagnostics(" Captured Err ")
-        content_all += format_as_diagnostics(report.capstderr.splitlines(keepends=True))
+        lines[-1] += "\n"
+        lines += [" Captured Err \n"] + (report.capstderr.splitlines(keepends=True) or [""])
 
-    return content_all
+    return format_as_diagnostics(lines)

--- a/src/pytest_tap/plugin.py
+++ b/src/pytest_tap/plugin.py
@@ -6,8 +6,8 @@ from tap.formatter import format_as_diagnostics
 from tap.tracker import Tracker
 
 SHOW_CAPTURE_LOG = ("log", "all")
-SHOW_CAPTURE_OUT = ("system-out", "out-err", "all")
-SHOW_CAPTUER_ERR = ("system-err", "out-err", "all")
+SHOW_CAPTURE_OUT = ("stdout", "all")
+SHOW_CAPTUER_ERR = ("stderr", "all")
 
 class TAPPlugin:
     def __init__(self, config: pytest.Config) -> None:
@@ -28,7 +28,7 @@ class TAPPlugin:
             # Disable it automatically for streaming.
             self._tracker.header = False
 
-        self.tap_logging = config.option.tap_logging
+        self.tap_logging = config.option.showcapture
         self.tap_log_passing_tests = config.option.tap_log_passing_tests
 
     @pytest.hookimpl()
@@ -150,14 +150,6 @@ def pytest_addoption(parser):
         help=(
             "An optional output directory to write TAP files to. "
             "If the directory does not exist, it will be created."
-        ),
-    )
-    group.addoption(
-        "--tap-logging",
-        default="no",
-        help=(
-            "Write captured log messages to TAP report: one of"
-            "no|log|system-out|system-err|out-err|all"
         ),
     )
     group.addoption(

--- a/src/pytest_tap/plugin.py
+++ b/src/pytest_tap/plugin.py
@@ -177,12 +177,18 @@ def _make_as_diagnostics(report, tap_logging):
 
     if tap_logging in ["log", "all"]:
         lines[-1] += "\n"
-        lines += ["--- Captured Log ---\n"] + (report.caplog.splitlines(keepends=True) or [""])
+        lines += ["--- Captured Log ---\n"] + (
+            report.caplog.splitlines(keepends=True) or [""]
+        )
     if tap_logging in ["system-out", "out-err", "all"]:
         lines[-1] += "\n"
-        lines += ["--- Captured Out ---\n"] + (report.capstdout.splitlines(keepends=True) or [""])
+        lines += ["--- Captured Out ---\n"] + (
+            report.capstdout.splitlines(keepends=True) or [""]
+        )
     if tap_logging in ["system-err", "out-err", "all"]:
         lines[-1] += "\n"
-        lines += ["--- Captured Err ---\n"] + (report.capstderr.splitlines(keepends=True) or [""])
+        lines += ["--- Captured Err ---\n"] + (
+            report.capstderr.splitlines(keepends=True) or [""]
+        )
 
     return format_as_diagnostics(lines)

--- a/src/pytest_tap/plugin.py
+++ b/src/pytest_tap/plugin.py
@@ -161,7 +161,7 @@ def pytest_addoption(parser):
         "--tap-log-passing-tests",
         default=False,
         action="store_true",
-        help="Capture log information for passing tests to TAP report"
+        help="Capture log information for passing tests to TAP report",
     )
 
 

--- a/src/pytest_tap/plugin.py
+++ b/src/pytest_tap/plugin.py
@@ -26,6 +26,7 @@ class TAPPlugin:
             self._tracker.header = False
 
         self.tap_logging = config.option.tap_logging
+        self.tap_log_passing_tests = config.option.tap_log_passing_tests
 
     @pytest.hookimpl()
     def pytest_runtestloop(self, session):
@@ -72,7 +73,10 @@ class TAPPlugin:
                 directive = "TODO unexpected success{}".format(reason)
                 self._tracker.add_ok(testcase, description, directive=directive)
         elif report.passed:
-            self._tracker.add_ok(testcase, description)
+            diagnostics = None
+            if self.tap_log_passing_tests:
+                diagnostics = _make_as_diagnostics(report, self.tap_logging)
+            self._tracker.add_ok(testcase, description, diagnostics=diagnostics)
         elif report.failed:
             diagnostics = _make_as_diagnostics(report, self.tap_logging)
 
@@ -152,6 +156,12 @@ def pytest_addoption(parser):
             "Write captured log messages to TAP report: one of"
             "no|log|system-out|system-err|out-err|all"
         ),
+    )
+    group.addoption(
+        "--tap-log-passing-tests",
+        default=False,
+        action="store_true",
+        help="Capture log information for passing tests to TAP report"
     )
 
 

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -7,6 +7,7 @@ def test_includes_options(testdir):
         "*--tap-files*",
         "*--tap-combined*",
         "*--tap-outdir=path*",
+        "*--tap-logging*"
     ]
     result.stdout.fnmatch_lines(expected_option_flags)
 

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -7,7 +7,7 @@ def test_includes_options(testdir):
         "*--tap-files*",
         "*--tap-combined*",
         "*--tap-outdir=path*",
-        "*--tap-logging*",
+        "*--tap-log-passing-tests*",
     ]
     result.stdout.fnmatch_lines(expected_option_flags)
 

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -7,7 +7,7 @@ def test_includes_options(testdir):
         "*--tap-files*",
         "*--tap-combined*",
         "*--tap-outdir=path*",
-        "*--tap-logging*"
+        "*--tap-logging*",
     ]
     result.stdout.fnmatch_lines(expected_option_flags)
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -90,10 +90,10 @@ def test_logging(testdir, sample_test_file):
     result = testdir.runpytest_subprocess("--tap", "--tap-logging", "all")
     result.stdout.fnmatch_lines(
         [
-            "# Captured Log",
-            "# Captured Out",
-            "# Captured Err",
-            "*Running test_not_ok*"
+            "# --- Captured Log ---",
+            "*Running test_not_ok*",
+            "# --- Captured Out ---",
+            "# --- Captured Err ---",
         ]
     )
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -103,8 +103,7 @@ def test_logging(testdir, sample_test_file):
 def test_log_passing_tests(testdir, sample_test_file):
     """Test logs are added to TAP diagnostics."""
     result = testdir.runpytest_subprocess(
-        "--tap",
-        "--tap-log-passing-tests", "--log-level", "INFO"
+        "--tap", "--tap-log-passing-tests", "--log-level", "INFO"
     )
     result.stdout.fnmatch_lines(
         [

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -101,7 +101,9 @@ def test_logging(testdir, sample_test_file):
 
 def test_log_passing_tests(testdir, sample_test_file):
     """Test logs are added to TAP diagnostics."""
-    result = testdir.runpytest_subprocess("--tap", "--tap-logging", "log", "--tap-log-passing-tests")
+    result = testdir.runpytest_subprocess(
+        "--tap", "--tap-logging", "log", "--tap-log-passing-tests"
+    )
     result.stdout.fnmatch_lines(
         [
             "# --- Captured Log ---",

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -102,7 +102,8 @@ def test_logging(testdir, sample_test_file):
 def test_log_passing_tests(testdir, sample_test_file):
     """Test logs are added to TAP diagnostics."""
     result = testdir.runpytest_subprocess(
-        "--tap", "--tap-logging", "log", "--tap-log-passing-tests"
+        "--tap", "--tap-logging", "log",
+        "--tap-log-passing-tests", "--log-level", "INFO"
     )
     result.stdout.fnmatch_lines(
         [

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -85,6 +85,7 @@ def test_outdir(testdir, sample_test_file):
     testresults = outdir.join("testresults.tap")
     assert testresults.check()
 
+
 def test_logging(testdir, sample_test_file):
     """Test logs are added to TAP diagnostics."""
     result = testdir.runpytest_subprocess("--tap", "--tap-logging", "all")
@@ -96,6 +97,7 @@ def test_logging(testdir, sample_test_file):
             "# --- Captured Err ---",
         ]
     )
+
 
 def test_xfail_no_reason(testdir):
     """xfails output gracefully when no reason is provided."""

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -85,6 +85,17 @@ def test_outdir(testdir, sample_test_file):
     testresults = outdir.join("testresults.tap")
     assert testresults.check()
 
+def test_logging(testdir, sample_test_file):
+    """Test logs are added to TAP diagnostics."""
+    result = testdir.runpytest_subprocess("--tap", "--tap-logging", "all")
+    result.stdout.fnmatch_lines(
+        [
+            "# Captured Log",
+            "# Captured Out",
+            "# Captured Err",
+            "*Running test_not_ok*"
+        ]
+    )
 
 def test_xfail_no_reason(testdir):
     """xfails output gracefully when no reason is provided."""

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -88,7 +88,7 @@ def test_outdir(testdir, sample_test_file):
 
 def test_logging(testdir, sample_test_file):
     """Test logs are added to TAP diagnostics."""
-    result = testdir.runpytest_subprocess("--tap", "--tap-logging", "all")
+    result = testdir.runpytest_subprocess("--tap")
     result.stdout.fnmatch_lines(
         [
             "# --- Captured Log ---",
@@ -97,12 +97,13 @@ def test_logging(testdir, sample_test_file):
             "# --- Captured Err ---",
         ]
     )
+    result.stdout.no_fnmatch_line("*Running test_ok*")
 
 
 def test_log_passing_tests(testdir, sample_test_file):
     """Test logs are added to TAP diagnostics."""
     result = testdir.runpytest_subprocess(
-        "--tap", "--tap-logging", "log",
+        "--tap",
         "--tap-log-passing-tests", "--log-level", "INFO"
     )
     result.stdout.fnmatch_lines(
@@ -111,6 +112,7 @@ def test_log_passing_tests(testdir, sample_test_file):
             "*Running test_ok*",
         ]
     )
+    result.stdout.no_fnmatch_line("*Debug logging info*")
 
 
 def test_xfail_no_reason(testdir):

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -99,6 +99,17 @@ def test_logging(testdir, sample_test_file):
     )
 
 
+def test_log_passing_tests(testdir, sample_test_file):
+    """Test logs are added to TAP diagnostics."""
+    result = testdir.runpytest_subprocess("--tap", "--tap-logging", "log", "--tap-log-passing-tests")
+    result.stdout.fnmatch_lines(
+        [
+            "# --- Captured Log ---",
+            "*Running test_ok*",
+        ]
+    )
+
+
 def test_xfail_no_reason(testdir):
     """xfails output gracefully when no reason is provided."""
     testdir.makepyfile(


### PR DESCRIPTION
resolves https://github.com/python-tap/pytest-tap/issues/91

This is based off the existing pytest JUnit logging support.

```
--tap-logging 'all'

1..6
ok 1 test_logging.py::test_ok
not ok 2 test_logging.py::test_not_ok
# def test_not_ok():
#         LOGGER.error("Running test_not_ok")
# >       assert False
# E       assert False
# 
# test_logging.py:12: AssertionError
# --- Captured Log ---
# ERROR    test_logging:test_logging.py:11 Running test_not_ok
# --- Captured Out ---
# 
# --- Captured Err ---
#
ok 3 test_logging.py::test_params[foo]
ok 4 test_logging.py::test_params[bar]
```
NOTE: Have PR to add logging to passing tests, but that requires an update to tappy.
tappy PR - https://github.com/python-tap/tappy/pull/148
pytest-tap PR - https://github.com/codambro/pytest-tap/pull/1

To accept your contribution, please complete the checklist below.

* [x] Is your name/identity in the AUTHORS file alphabetically?
* [x] Did you write a test to verify your code change?
* [x] Is CI passing?
