### PR TITLE
Revert "Support TAP13 YAML"

### DIFF
--- a/src/pytest_tap/plugin.py
+++ b/src/pytest_tap/plugin.py
@@ -3,7 +3,7 @@ import sys
 
 import pytest
 from tap.formatter import format_as_diagnostics
-from tap.tracker import ENABLE_VERSION_13, Tracker
+from tap.tracker import Tracker
 
 SHOW_CAPTURE_LOG = ("log", "all")
 SHOW_CAPTURE_OUT = ("stdout", "all")
@@ -83,9 +83,6 @@ class TAPPlugin:
             self._tracker.add_ok(testcase, description, diagnostics=diagnostics)
         elif report.failed:
             diagnostics = _make_as_diagnostics(report, self.show_capture)
-            raw_yaml_block = (
-                _make_as_raw_yaml_block(report) if ENABLE_VERSION_13 else None
-            )
 
             # pytest treats an unexpected success from unitest.expectedFailure
             # as a failure.
@@ -111,12 +108,7 @@ class TAPPlugin:
                 )
                 return
 
-            self._tracker.add_not_ok(
-                testcase,
-                description,
-                diagnostics=diagnostics,
-                raw_yaml_block=raw_yaml_block,
-            )
+            self._tracker.add_not_ok(testcase, description, diagnostics=diagnostics)
         elif report.skipped:
             reason = report.longrepr[2].split(":", 1)[1].strip()  # type: ignore
             self._tracker.add_skip(testcase, description, reason)
@@ -209,18 +201,3 @@ def _make_as_diagnostics(report, show_capture):
         )
 
     return format_as_diagnostics(lines)
-
-
-def _make_as_raw_yaml_block(report):
-    try:
-        lines = report.longrepr.reprcrash.message.splitlines(keepends=True)
-    except AttributeError:
-        lines = report.longreprtext.splitlines(keepends=True)
-    res = f"""\
-message: |
-{"".join(f"  {line}" for line in lines)}
-severity: {report.outcome}
-duration_ms: {report.duration * 1000}"""
-    if hasattr(report, "user_properties"):
-        res += "\n" + "\n".join(f"{k}: {v}" for k, v in report.user_properties)
-    return res


### PR DESCRIPTION
## Summary
- revert merge commit `bd2d14bd1cdc888708da36226823adc3f33acfec` from `python-tap/pytest-tap#109`
- remove the TAP13 YAML support changes introduced in `src/pytest_tap/plugin.py`
- restore the pre-`#109` plugin behavior

## Testing
- `uv run pytest -q`