### PR TITLE
Include conftest.py in the sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ include = [
     "/src",
     "/docs",
     "/tests",
+    "/conftest.py",
 ]
 
 [tool.hatch.build.targets.wheel]


### PR DESCRIPTION
The root conftest.py provides the sample_test_file fixture used by the test suite, but it is excluded from the sdist because it is outside the hatchling sdist include list. This makes the PyPI tarball untestable as-is and forces downstream packagers to patch the file back in.

Fixes #107